### PR TITLE
Agrega servicio rstudio

### DIFF
--- a/Dockerfile.rstudio
+++ b/Dockerfile.rstudio
@@ -1,0 +1,7 @@
+FROM rocker/rstudio
+
+COPY . /workdir
+RUN Rscript -e "install.packages(c('kernlab', 'optimx', 'remotes', 'rgenoud'), repos='http://cran.rstudio.com')"
+RUN Rscript -e "remotes::install_github('pako841212/LR')"
+RUN Rscript -e "remotes::install_github('pako841212/synth')"
+RUN Rscript -e "install.packages('gsynth', repos = 'http://cran.us.r-project.org')"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,26 @@ services:
     command: bash
     volumes:
       - $PWD:/workdir
+
+  rstudio_synth:
+    build:
+      context: .
+      dockerfile: Dockerfile.rstudio
+    container_name: cont-rstudio
+    restart: always
+    volumes:
+      - type: volume
+        source: rstudio_synth
+        target: $PWD
+      - type: bind
+        source: $PWD
+        target: /home/rstudio
+    networks: 
+      - default
+    environment:
+      - PASSWORD=rstudio
+    ports:
+      - 5050:8787
+
+volumes:
+  rstudio_synth:

--- a/src/example.R
+++ b/src/example.R
@@ -27,7 +27,7 @@ df$Y <- ifelse(df$state == "A" & df$year >= 15, df$Y + 20, df$Y)
 str(df)
 head(df)
 #Maintenant on peut estimer les models, d'abord nous allons utiliser Synth. En suite, on peut observer les poids des variables indépendants(v.weights) et des groupes de control (w.weights)
-ataprep.out <-
+dataprep.out <-
         dataprep(df,
                  predictors = c("X1", "X2"),
                  dependent     = "Y",

--- a/src/example.R
+++ b/src/example.R
@@ -47,7 +47,7 @@ synth.out <- synth(dataprep.out)
 #Obtinir grille des résultats
 print(synth.tables   <- synth.tab(
         dataprep.res = dataprep.out,
-        synth.res    = synth.out)
+        synth.res    = synth.out))
 #Plot:
 path.plot(synth.res    = synth.out,
           dataprep.res = dataprep.out,


### PR DESCRIPTION
En el `docker-compose.yml` agrega servicio para poder correr rstudio en el puerto 5050. Agrega `Dockerfile.rstudio` que se usa para levantar el servicio rstudio. El dockerfile instala los paquetes necesarios para correr el archivo `src/example.R`.

En el archivo `src/example.R` agrega una leta y un paréntesis faltantes.